### PR TITLE
Fix zarith conversion bug

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1329,7 +1329,7 @@ function forgeZarith(n){
   n = parseInt(n);
   while(true){
     if (n < 128){
-      if (n < 15) fn += "0";
+      if (n < 16) fn += "0";
       fn += n.toString(16);
       break;
     } else {


### PR DESCRIPTION
Description
There's a bug in the `forgeZarith` function, where outputs may be wrong. Should the ending output byte be `0f`, the bugged function will return f instead. This generates an invalid hex. When checking the forged tx against the tx returned by the RPC the tx will fail due to a mismatch.

Outcome
Instead of succeeding the tx will fail.

Demo
The bug can be tested by passing as param a zarith number whose hex encoding last byte is `0f`. This can be passed as custom fee, as gas limit, or storage fee. 

Example test values
Custom fee: `1920`
Gas limit: `250000`
Storage limit: `1930`